### PR TITLE
Add missing group id.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clojusc/shankha "0.2.0-SNAPSHOT"
   :description "A Divine Shell"
-  :url "https://github.com/oubiwann/shankha"
+  :url "https://github.com/clojusc/shankha"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject shankha "0.2.0-SNAPSHOT"
+(defproject clojusc/shankha "0.2.0-SNAPSHOT"
   :description "A Divine Shell"
   :url "https://github.com/oubiwann/shankha"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This should fix the broken Clojars link, issue #17.
